### PR TITLE
Update dashboard to use invoice-data

### DIFF
--- a/src/app/invoice-data.json
+++ b/src/app/invoice-data.json
@@ -1,0 +1,673 @@
+[
+  {
+    "transaction_id": "79499406b8610b5ec5c0284c07e92f30",
+    "source_log_file": "JobsResults22052025.txt",
+    "run_start_time": "2025-05-22 12:08:55",
+    "run_end_time": null,
+    "email_response_status_code": null,
+    "total_email_count": null,
+    "subject": "Unknown Subject",
+    "files_processed": [],
+    "total_attachments_in_run": 0,
+    "files_successfully_processed": 0,
+    "files_failed_processing": 0,
+    "run_status": "Incomplete",
+    "applied_rules": []
+  },
+  {
+    "transaction_id": "20f16ec84c1eceb599e40752a07c0f3d",
+    "source_log_file": "JobsResults22052025.txt",
+    "run_start_time": "2025-05-22 12:09:24",
+    "run_end_time": "2025-05-22 12:09:53",
+    "email_response_status_code": "200",
+    "total_email_count": "1",
+    "subject": "FW: Exception_PDF's_JuneTest_LNIP",
+    "files_processed": [
+      {
+        "id": "e317915f7f1847e19ff2749f925f45fc",
+        "file_name": "corruptedInvoice.pdf",
+        "bod_id": null,
+        "bod_status": null,
+        "doc_added_to_idm": false,
+        "notification_sent": false,
+        "idp_status": "Exception: Bad Request while Polling OCR.",
+        "idp_response_code": null,
+        "fields": null,
+        "items": [],
+        "file_status": "Failed",
+        "raw_content_snippet": "Exception occured while reading the email:Unexpected Error occured in ProcessInvoice Activity: Unexpected Error occured in Invoke ExtractAttributesfromDocument Activity: Unexpected Error occured in Extract Data Activity: Bad Request while Polling OCR.\n",
+        "errors": [
+          "Unexpected Error occured in ProcessInvoice Activity: Unexpected Error occured in Invoke ExtractAttributesfromDocument Activity: Unexpected Error occured in Extract Data Activity: Bad Request while Polling OCR."
+        ]
+      }
+    ],
+    "total_attachments_in_run": 1,
+    "files_successfully_processed": 0,
+    "files_failed_processing": 1,
+    "run_status": "Failed (All Files Failed)",
+    "applied_rules": []
+  },
+  {
+    "transaction_id": "76fbaa3a71290987114b655d56c6c26a",
+    "source_log_file": "JobsResults22052025.txt",
+    "run_start_time": "2025-05-22 17:27:36",
+    "run_end_time": "2025-05-22 17:27:38",
+    "email_response_status_code": "400",
+    "total_email_count": "0",
+    "subject": "Unknown Subject",
+    "files_processed": [],
+    "total_attachments_in_run": 0,
+    "files_successfully_processed": 0,
+    "files_failed_processing": 0,
+    "run_status": "Completed (No Attachments)",
+    "applied_rules": []
+  },
+  {
+    "transaction_id": "f13981a2c1fc2b3d910dc33cb08e2291",
+    "source_log_file": "JobsResults22052025.txt",
+    "run_start_time": "2025-05-22 18:13:29",
+    "run_end_time": "2025-05-22 18:13:40",
+    "email_response_status_code": "200",
+    "total_email_count": "2",
+    "subject": "RE: Status on Server Provisoning",
+    "files_processed": [],
+    "total_attachments_in_run": 0,
+    "files_successfully_processed": 0,
+    "files_failed_processing": 0,
+    "run_status": "Completed (No Attachments)",
+    "applied_rules": []
+  },
+  {
+    "transaction_id": "7bed625f4b770a1e8c2356c49f9274db",
+    "source_log_file": "JobsResults22052025.txt",
+    "run_start_time": "2025-05-22 18:17:41",
+    "run_end_time": "2025-05-22 18:18:44",
+    "email_response_status_code": "200",
+    "total_email_count": "1",
+    "subject": "FW: DPI less than 300",
+    "files_processed": [
+      {
+        "id": "3394f4fd54734abf985dc164bed2e8fc",
+        "file_name": "Wilson Construction 118046.pdf",
+        "bod_id": "20250522181828598-118046",
+        "bod_status": "Failure Status Code: 412",
+        "doc_added_to_idm": true,
+        "notification_sent": true,
+        "idp_status": "Success",
+        "idp_response_code": 200,
+        "fields": {
+          "invoice_number": "118046",
+          "invoice_date": "2025-01-09",
+          "purchase_order": "",
+          "subtotal": "626.40",
+          "total": "681.52",
+          "currency": "USD",
+          "vendor": "Wenatchee Clinic",
+          "payment_terms": "",
+          "vat_registration_number": "",
+          "organisation_number": "",
+          "iban": "",
+          "discount": "",
+          "packing_slip_number": "",
+          "other_charges": "",
+          "charges_descriptions": "",
+          "invoice_type": "Expense Invoice",
+          "bban": "100.111.8432.760210",
+          "discount_description": ""
+        },
+        "items": [
+          {
+            "item_code": null,
+            "description": "Repair leaky Shower",
+            "unit_price": "80.00",
+            "quantity": "7",
+            "subtotal": "560.00"
+          },
+          {
+            "item_code": null,
+            "description": "materials - Tile,calk, Morter and Grout",
+            "unit_price": null,
+            "quantity": null,
+            "subtotal": "66.40"
+          }
+        ],
+        "file_status": "Failed",
+        "raw_content_snippet": "Extracting Invoice Data using IDP...\nIDP Response: 200\nIndex : 0 Invoice Number : 118046\nIndex : 1 Invoice Date : 2025-01-09\nIndex : 2 Purchase Order(Number) : \nIndex : 3 Sub Total : 626.40\nIndex : 4 Total Amount : 681.52\nIndex : 5 Currency : USD\nIndex : 6 Vendor Name : Wenatchee Clinic\nIndex : 7 Payment Terms : \nIndex : 8 VAT Registration Number : \nIndex : 9 Organisation Number : \nIndex : 10 IBAN : \nIndex : 11 Discount : \nIndex : 12 Packing Slip Number : \nIndex : 13 Other Charges : \nIndex : 14 ",
+        "errors": []
+      }
+    ],
+    "total_attachments_in_run": 1,
+    "files_successfully_processed": 0,
+    "files_failed_processing": 1,
+    "run_status": "Failed (All Files Failed)",
+    "applied_rules": [
+      {
+        "rule_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        "rule_name": "Flag Failed BOD Status",
+        "action": "flag_bod_failure",
+        "matched_field": "bod_status",
+        "matched_value": "Failure Status Code: 412",
+        "context": "File: Wilson Construction 118046.pdf"
+      }
+    ]
+  },
+  {
+    "transaction_id": "64af14c527fac20bb6e34e11c31b7c5a",
+    "source_log_file": "JobsResults24052025.txt",
+    "run_start_time": "2025-05-24 21:23:52",
+    "run_end_time": "2025-05-24 21:24:42",
+    "email_response_status_code": "200",
+    "total_email_count": "1",
+    "subject": "Expense L",
+    "files_processed": [
+      {
+        "id": "c51c7e77a36b40c8b549ba1899c56c51",
+        "file_name": "INV - Example 2.pdf",
+        "bod_id": "20250524212437342-QK20210724L",
+        "bod_status": "Success",
+        "doc_added_to_idm": true,
+        "notification_sent": true,
+        "idp_status": "Success",
+        "idp_response_code": 200,
+        "fields": {
+          "invoice_number": "QK20210724L",
+          "invoice_date": "2025-05-07",
+          "purchase_order": "",
+          "subtotal": "29484.00",
+          "total": "29484.00",
+          "currency": "USD",
+          "vendor": "Shenzhen BSO Building Material Co.,Ltd.",
+          "payment_terms": "TT 30 DAYS FROM INVOICE DATE",
+          "vat_registration_number": "91440300699085158",
+          "organisation_number": "",
+          "iban": "",
+          "discount": "",
+          "packing_slip_number": "",
+          "other_charges": "",
+          "charges_descriptions": "",
+          "invoice_type": "Expense Invoice",
+          "bban": "127838258838",
+          "discount_description": ""
+        },
+        "items": [
+          {
+            "item_code": "21.093.09",
+            "description": "Uitloop NF square BLK",
+            "unit_price": "15.21",
+            "quantity": "780",
+            "subtotal": "11863.80"
+          },
+          {
+            "item_code": "20.425.09",
+            "description": "Hendel MK/NF BLK",
+            "unit_price": "1.26",
+            "quantity": "780",
+            "subtotal": "982.80"
+          },
+          {
+            "item_code": "20.450.09",
+            "description": "Knop NF BLK",
+            "unit_price": "8.70",
+            "quantity": "780",
+            "subtotal": "6786.00"
+          },
+          {
+            "item_code": "21.172.09",
+            "description": "Set Kap en buitenmantel NF BLK",
+            "unit_price": "12.63",
+            "quantity": "780",
+            "subtotal": "9851.40"
+          }
+        ],
+        "file_status": "Success",
+        "raw_content_snippet": "Extracting Invoice Data using IDP...\nIDP Response: 200\nIndex : 0 Invoice Number : QK20210724L\nIndex : 1 Invoice Date : 2025-05-07\nIndex : 2 Purchase Order(Number) : \nIndex : 3 Sub Total : 29484.00\nIndex : 4 Total Amount : 29484.00\nIndex : 5 Currency : USD\nIndex : 6 Vendor Name : Shenzhen BSO Building Material Co.,Ltd.\nIndex : 7 Payment Terms : TT 30 DAYS FROM INVOICE DATE\nIndex : 8 VAT Registration Number : 91440300699085158\nIndex : 9 Organisation Number : \nIndex : 10 IBAN : \nIndex : 11 Discount",
+        "errors": []
+      }
+    ],
+    "total_attachments_in_run": 1,
+    "files_successfully_processed": 1,
+    "files_failed_processing": 0,
+    "run_status": "Completed",
+    "applied_rules": []
+  },
+  {
+    "transaction_id": "245cb9c4e0cd9619ee4cd6898f7ff410",
+    "source_log_file": "JobsResults24052025.txt",
+    "run_start_time": "2025-05-24 21:35:31",
+    "run_end_time": "2025-05-24 21:39:23",
+    "email_response_status_code": "200",
+    "total_email_count": "2",
+    "subject": "Exception_PDF's_JuneTest_LNIP",
+    "files_processed": [
+      {
+        "id": "419ec34c58df4f7b847f7c52afdebf1f",
+        "file_name": "corruptedInvoice.pdf",
+        "bod_id": null,
+        "bod_status": null,
+        "doc_added_to_idm": false,
+        "notification_sent": false,
+        "idp_status": "IDP Exception: Unexpected Error occured in Extract Data Activity: Bad Request while Polling OCR.",
+        "idp_response_code": null,
+        "fields": null,
+        "items": [],
+        "file_status": "Failed",
+        "raw_content_snippet": "IDP ExceptionUnexpected Error occured in Extract Data Activity: Bad Request while Polling OCR.\n==========================================================\n",
+        "errors": []
+      },
+      {
+        "id": "a2aba134d6914f49b6adeaa14a7953e9",
+        "file_name": "DPF.pdf",
+        "bod_id": null,
+        "bod_status": null,
+        "doc_added_to_idm": false,
+        "notification_sent": false,
+        "idp_status": "IDP Exception: Unexpected Error occured in Extract Data Activity: Bad Request while Polling OCR.",
+        "idp_response_code": null,
+        "fields": null,
+        "items": [],
+        "file_status": "Failed",
+        "raw_content_snippet": "IDP ExceptionUnexpected Error occured in Extract Data Activity: Bad Request while Polling OCR.\n==========================================================\n",
+        "errors": []
+      },
+      {
+        "id": "001a392b1e394caaabe23a7a6810a160",
+        "file_name": "invoice.final.v3.2025..pdf",
+        "bod_id": null,
+        "bod_status": null,
+        "doc_added_to_idm": false,
+        "notification_sent": false,
+        "idp_status": "IDP Exception: Unexpected Error occured in Extract Data Activity: Bad Request while Polling OCR.",
+        "idp_response_code": null,
+        "fields": null,
+        "items": [],
+        "file_status": "Failed",
+        "raw_content_snippet": "IDP ExceptionUnexpected Error occured in Extract Data Activity: Bad Request while Polling OCR.\n==========================================================\n",
+        "errors": []
+      },
+      {
+        "id": "144c60dde48445cb8801182b802fd21d",
+        "file_name": "Inv_003_(Final_Ver)_2025%Approved.pdf",
+        "bod_id": "20250524213833326-2402182",
+        "bod_status": "Success",
+        "doc_added_to_idm": true,
+        "notification_sent": true,
+        "idp_status": "Success",
+        "idp_response_code": 200,
+        "fields": {
+          "invoice_number": "2402182",
+          "invoice_date": "2025-10-22",
+          "purchase_order": "PO0000169",
+          "subtotal": "27.00",
+          "total": "27.00",
+          "currency": "EUR",
+          "vendor": "Bohao Prototype Manufacturing Co.,Limited",
+          "payment_terms": "30 days netto",
+          "vat_registration_number": "NL808503819B01",
+          "organisation_number": "",
+          "iban": "",
+          "discount": "",
+          "packing_slip_number": "",
+          "other_charges": "",
+          "charges_descriptions": "",
+          "invoice_type": "PO Invoice",
+          "bban": "015515680167070",
+          "discount_description": ""
+        },
+        "items": [
+          {
+            "item_code": null,
+            "description": "lense for optical sensor",
+            "unit_price": "9.00",
+            "quantity": "3",
+            "subtotal": "27.00"
+          }
+        ],
+        "file_status": "Success",
+        "raw_content_snippet": "Extracting Invoice Data using IDP...\nIDP Response: 200\nIndex : 0 Invoice Number : 2402182\nIndex : 1 Invoice Date : 2025-10-22\nIndex : 2 Purchase Order(Number) : PO0000169\nIndex : 3 Sub Total : 27.00\nIndex : 4 Total Amount : 27.00\nIndex : 5 Currency : EUR\nIndex : 6 Vendor Name : Bohao Prototype Manufacturing Co.,Limited\nIndex : 7 Payment Terms : 30 days netto\nIndex : 8 VAT Registration Number : NL808503819B01\nIndex : 9 Organisation Number : \nIndex : 10 IBAN : \nIndex : 11 Discount : \nIndex : 12 Pa",
+        "errors": []
+      },
+      {
+        "id": "221c7cfba4794b5da03d2d0bffcef47c",
+        "file_name": "INV - Example 2.pdf",
+        "bod_id": "20250524213916560-QK20210724L",
+        "bod_status": "Success",
+        "doc_added_to_idm": true,
+        "notification_sent": true,
+        "idp_status": "Success",
+        "idp_response_code": 200,
+        "fields": {
+          "invoice_number": "QK20210724L",
+          "invoice_date": "2025-05-07",
+          "purchase_order": "",
+          "subtotal": "29484.00",
+          "total": "29484.00",
+          "currency": "USD",
+          "vendor": "Shenzhen BSO Building Material Co.,Ltd.",
+          "payment_terms": "TT 30 DAYS FROM INVOICE DATE",
+          "vat_registration_number": "91440300699085158",
+          "organisation_number": "",
+          "iban": "",
+          "discount": "",
+          "packing_slip_number": "",
+          "other_charges": "",
+          "charges_descriptions": "",
+          "invoice_type": "Expense Invoice",
+          "bban": "127838258838",
+          "discount_description": ""
+        },
+        "items": [
+          {
+            "item_code": "21.093.09",
+            "description": "Uitloop NF square BLK",
+            "unit_price": "15.21",
+            "quantity": "780",
+            "subtotal": "11863.80"
+          },
+          {
+            "item_code": "20.425.09",
+            "description": "Hendel MK/NF BLK",
+            "unit_price": "1.26",
+            "quantity": "780",
+            "subtotal": "982.80"
+          },
+          {
+            "item_code": "20.450.09",
+            "description": "Knop NF BLK",
+            "unit_price": "8.70",
+            "quantity": "780",
+            "subtotal": "6786.00"
+          },
+          {
+            "item_code": "21.172.09",
+            "description": "Set Kap en buitenmantel NF BLK",
+            "unit_price": "12.63",
+            "quantity": "780",
+            "subtotal": "9851.40"
+          }
+        ],
+        "file_status": "Success",
+        "raw_content_snippet": "Extracting Invoice Data using IDP...\nIDP Response: 200\nIndex : 0 Invoice Number : QK20210724L\nIndex : 1 Invoice Date : 2025-05-07\nIndex : 2 Purchase Order(Number) : \nIndex : 3 Sub Total : 29484.00\nIndex : 4 Total Amount : 29484.00\nIndex : 5 Currency : USD\nIndex : 6 Vendor Name : Shenzhen BSO Building Material Co.,Ltd.\nIndex : 7 Payment Terms : TT 30 DAYS FROM INVOICE DATE\nIndex : 8 VAT Registration Number : 91440300699085158\nIndex : 9 Organisation Number : \nIndex : 10 IBAN : \nIndex : 11 Discount",
+        "errors": []
+      }
+    ],
+    "total_attachments_in_run": 5,
+    "files_successfully_processed": 2,
+    "files_failed_processing": 3,
+    "run_status": "Partial Success",
+    "applied_rules": []
+  },
+  {
+    "transaction_id": "66821169289cf44d162844470619a5ae",
+    "source_log_file": "JobsResults27052025.txt",
+    "run_start_time": "2025/05/27 20:39:52",
+    "run_end_time": "2025/05/27 20:40:39",
+    "email_response_status_code": "200",
+    "total_email_count": "1",
+    "subject": "Expense",
+    "files_processed": [
+      {
+        "id": "62e5f0f9dd94488caca8ba5457c3913c",
+        "file_name": "BP0145244 FEDEX.pdf",
+        "bod_id": null,
+        "bod_status": null,
+        "doc_added_to_idm": false,
+        "notification_sent": false,
+        "idp_status": "Success",
+        "idp_response_code": 200,
+        "fields": {
+          "invoice_number": "1234567891",
+          "invoice_date": "2025-02-20",
+          "purchase_order": "",
+          "subtotal": "",
+          "total": "",
+          "currency": "USD",
+          "vendor": "FedEx",
+          "payment_terms": "Your payment is due by Mar 07, 2025",
+          "vat_registration_number": "",
+          "organisation_number": "",
+          "iban": "",
+          "discount": "",
+          "packing_slip_number": "",
+          "other_charges": "",
+          "charges_descriptions": "",
+          "invoice_type": "Expense Invoice",
+          "bban": "",
+          "discount_description": ""
+        },
+        "items": [],
+        "file_status": "Failed",
+        "raw_content_snippet": "Extracting Invoice Data using IDP...\nIDP Response: 200\nIndex : 0 Invoice Number : 1234567891\nIndex : 1 Invoice Date : 2025-02-20\nIndex : 2 Purchase Order(Number) : \nIndex : 3 Sub Total : \nIndex : 4 Total  Amount : \nIndex : 5 Currency : USD\nIndex : 6 Vendor Name : FedEx\nIndex : 7 Payment Terms : Your payment is due by Mar 07, 2025\nIndex : 8 VAT Registration  Number : \nIndex : 9 Organisation Number : \nIndex : 10 IBAN : \nIndex : 11 Discount : \nIndex : 12 Packing Slip Number : \nIndex : 13 Other  Cha",
+        "errors": []
+      }
+    ],
+    "total_attachments_in_run": 1,
+    "files_successfully_processed": 0,
+    "files_failed_processing": 1,
+    "run_status": "Failed (All Files Failed)",
+    "applied_rules": []
+  },
+  {
+    "transaction_id": "95eb238893d3f0bd8b3e141d5941a557",
+    "source_log_file": "JobsResults29052025.txt",
+    "run_start_time": "2025/05/29 10:42:27",
+    "run_end_time": "2025/05/29 10:43:16",
+    "email_response_status_code": "200",
+    "total_email_count": "1",
+    "subject": "PO38_IN1313",
+    "files_processed": [
+      {
+        "id": "71baaa35e16d4235a8ba8adae7bcc747",
+        "file_name": "BP0207204 HENDRICKSON BUMPER_29May.pdf",
+        "bod_id": "20250529104311962-11214981",
+        "bod_status": "Success",
+        "doc_added_to_idm": true,
+        "notification_sent": true,
+        "idp_status": "Success",
+        "idp_response_code": 200,
+        "fields": {
+          "invoice_number": "11214981",
+          "invoice_date": "2025-05-29",
+          "purchase_order": "PPA000038",
+          "subtotal": "",
+          "total": "545.55",
+          "currency": "USD",
+          "vendor": "Hendrickson, USA, LLC.",
+          "payment_terms": "NET 45 DAYS",
+          "vat_registration_number": "",
+          "organisation_number": "",
+          "iban": "",
+          "discount": "",
+          "packing_slip_number": "1313",
+          "other_charges": "",
+          "charges_descriptions": "",
+          "invoice_type": "PO Invoice",
+          "bban": "",
+          "discount_description": ""
+        },
+        "items": [
+          {
+            "item_code": "104732XT",
+            "description": "SP BB CVFE BUSREAR BPRCF 22-",
+            "unit_price": "181.85",
+            "quantity": "3",
+            "subtotal": "545.55"
+          }
+        ],
+        "file_status": "Success",
+        "raw_content_snippet": "Extracting Invoice Data using IDP...\nIDP Response: 200\nIndex : 0 Invoice Number : 11214981\nIndex : 1 Invoice Date : 2025-05-29\nIndex : 2 Purchase Order(Number) : PPA000038\nIndex : 3 Sub Total : \nIndex : 4 Total Amount : 545.55\nIndex : 5 Currency : USD\nIndex : 6 Vendor Name : Hendrickson, USA, LLC.\nIndex : 7 Payment Terms : NET 45 DAYS\nIndex : 8 VAT Registration Number : \nIndex : 9 Organisation Number : \nIndex : 10 IBAN : \nIndex : 11 Discount : \nIndex : 12 Packing Slip Number : 1313\nIndex : 13 Ot",
+        "errors": []
+      }
+    ],
+    "total_attachments_in_run": 1,
+    "files_successfully_processed": 1,
+    "files_failed_processing": 0,
+    "run_status": "Completed",
+    "applied_rules": []
+  },
+  {
+    "transaction_id": "afe16f545fdf043a03b244e2c5431d84",
+    "source_log_file": "JobsResults29052025.txt",
+    "run_start_time": "2025/05/29 11:25:44",
+    "run_end_time": "2025/05/29 11:26:33",
+    "email_response_status_code": "200",
+    "total_email_count": "1",
+    "subject": "Expense (987654322)",
+    "files_processed": [
+      {
+        "id": "41a24e1f1cb64d259f18836bc40db46e",
+        "file_name": "BP0145244 FEDEX_Expense (987654321).pdf",
+        "bod_id": "20250529112628479-987654322",
+        "bod_status": "Success",
+        "doc_added_to_idm": true,
+        "notification_sent": true,
+        "idp_status": "Success",
+        "idp_response_code": 200,
+        "fields": {
+          "invoice_number": "987654322",
+          "invoice_date": "2025-02-20",
+          "purchase_order": "",
+          "subtotal": "",
+          "total": "133.61",
+          "currency": "USD",
+          "vendor": "FedEx",
+          "payment_terms": "Payment is due by Mar 07, 2025",
+          "vat_registration_number": "",
+          "organisation_number": "",
+          "iban": "",
+          "discount": "",
+          "packing_slip_number": "",
+          "other_charges": "",
+          "charges_descriptions": "",
+          "invoice_type": "Expense Invoice",
+          "bban": "",
+          "discount_description": ""
+        },
+        "items": [],
+        "file_status": "Success",
+        "raw_content_snippet": "Extracting Invoice Data using IDP...\nIDP Response: 200\nIndex : 0 Invoice Number : 987654322\nIndex : 1 Invoice Date : 2025-02-20\nIndex : 2 Purchase Order(Number) : \nIndex : 3 Sub Total : \nIndex : 4 Total Amount : 133.61\nIndex : 5 Currency : USD\nIndex : 6 Vendor Name : FedEx\nIndex : 7 Payment Terms : Payment is due by Mar 07, 2025\nIndex : 8 VAT Registration Number : \nIndex : 9 Organisation Number : \nIndex : 10 IBAN : \nIndex : 11 Discount : \nIndex : 12 Packing Slip Number : \nIndex : 13 Other Charge",
+        "errors": []
+      }
+    ],
+    "total_attachments_in_run": 1,
+    "files_successfully_processed": 1,
+    "files_failed_processing": 0,
+    "run_status": "Completed",
+    "applied_rules": []
+  },
+  {
+    "transaction_id": "4165ccc3af1ba45a4be1dcd63e8c240c",
+    "source_log_file": "JobsResults29052025.txt",
+    "run_start_time": "2025/05/29 11:57:59",
+    "run_end_time": "2025/05/29 11:58:49",
+    "email_response_status_code": "200",
+    "total_email_count": "1",
+    "subject": "IN82_PO39",
+    "files_processed": [
+      {
+        "id": "7dff6c34611440608c3dd2c199597d2d",
+        "file_name": "BP0207204 HENDRICKSON BUMPER_29May.pdf",
+        "bod_id": "20250529115844743-11214982",
+        "bod_status": "Success",
+        "doc_added_to_idm": true,
+        "notification_sent": true,
+        "idp_status": "Success",
+        "idp_response_code": 200,
+        "fields": {
+          "invoice_number": "11214982",
+          "invoice_date": "2025-05-29",
+          "purchase_order": "PPA000039",
+          "subtotal": "545.55",
+          "total": "545.55",
+          "currency": "USD",
+          "vendor": "Hendrickson, USA, LLC.",
+          "payment_terms": "NET 45 DAYS",
+          "vat_registration_number": "",
+          "organisation_number": "",
+          "iban": "",
+          "discount": "",
+          "packing_slip_number": "1414",
+          "other_charges": "",
+          "charges_descriptions": "",
+          "invoice_type": "PO Invoice",
+          "bban": "",
+          "discount_description": ""
+        },
+        "items": [
+          {
+            "item_code": "104732XT",
+            "description": "SP BB CVFE BUSREAR BPRCF 22-",
+            "unit_price": "181.85",
+            "quantity": "3",
+            "subtotal": "545.55"
+          }
+        ],
+        "file_status": "Success",
+        "raw_content_snippet": "Extracting Invoice Data using IDP...\nIDP Response: 200\nIndex : 0 Invoice Number : 11214982\nIndex : 1 Invoice Date : 2025-05-29\nIndex : 2 Purchase Order(Number) : PPA000039\nIndex : 3 Sub Total : 545.55\nIndex : 4 Total Amount : 545.55\nIndex : 5 Currency : USD\nIndex : 6 Vendor Name : Hendrickson, USA, LLC.\nIndex : 7 Payment Terms : NET 45 DAYS\nIndex : 8 VAT Registration Number : \nIndex : 9 Organisation Number : \nIndex : 10 IBAN : \nIndex : 11 Discount : \nIndex : 12 Packing Slip Number : 1414\nIndex :",
+        "errors": []
+      }
+    ],
+    "total_attachments_in_run": 1,
+    "files_successfully_processed": 1,
+    "files_failed_processing": 0,
+    "run_status": "Completed",
+    "applied_rules": []
+  },
+  {
+    "transaction_id": "4f0d83edfcdd5f51fc471189a7ef566e",
+    "source_log_file": "JobsResults29052025.txt",
+    "run_start_time": "2025/05/29 12:06:43",
+    "run_end_time": "2025/05/29 12:07:32",
+    "email_response_status_code": "200",
+    "total_email_count": "1",
+    "subject": "IN82_PO39",
+    "files_processed": [
+      {
+        "id": "d67bc279e6dc4ed89e5460eb2cebfbff",
+        "file_name": "BP0207204 HENDRICKSON BUMPER_29May.pdf",
+        "bod_id": "20250529120728092-11214982",
+        "bod_status": "Success",
+        "doc_added_to_idm": true,
+        "notification_sent": true,
+        "idp_status": "Success",
+        "idp_response_code": 200,
+        "fields": {
+          "invoice_number": "11214982",
+          "invoice_date": "2025-05-29",
+          "purchase_order": "PPA000039",
+          "subtotal": "545.55",
+          "total": "545.55",
+          "currency": "USD",
+          "vendor": "Hendrickson, USA, LLC.",
+          "payment_terms": "NET 45 DAYS",
+          "vat_registration_number": "",
+          "organisation_number": "",
+          "iban": "",
+          "discount": "",
+          "packing_slip_number": "1414",
+          "other_charges": "",
+          "charges_descriptions": "",
+          "invoice_type": "PO Invoice",
+          "bban": "",
+          "discount_description": ""
+        },
+        "items": [
+          {
+            "item_code": "104732XT",
+            "description": "SP BB CVFE BUSREAR BPRCF 22-",
+            "unit_price": "181.85",
+            "quantity": "3",
+            "subtotal": "545.55"
+          }
+        ],
+        "file_status": "Success",
+        "raw_content_snippet": "Extracting Invoice Data using IDP...\nIDP Response: 200\nIndex : 0 Invoice Number : 11214982\nIndex : 1 Invoice Date : 2025-05-29\nIndex : 2 Purchase Order(Number) : PPA000039\nIndex : 3 Sub Total : 545.55\nIndex : 4 Total Amount : 545.55\nIndex : 5 Currency : USD\nIndex : 6 Vendor Name : Hendrickson, USA, LLC.\nIndex : 7 Payment Terms : NET 45 DAYS\nIndex : 8 VAT Registration Number : \nIndex : 9 Organisation Number : \nIndex : 10 IBAN : \nIndex : 11 Discount : \nIndex : 12 Packing Slip Number : 1414\nIndex :",
+        "errors": []
+      }
+    ],
+    "total_attachments_in_run": 1,
+    "files_successfully_processed": 1,
+    "files_failed_processing": 0,
+    "run_status": "Completed",
+    "applied_rules": []
+  }
+]

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,10 +5,42 @@ import { SectionCards } from "@/components/section-cards";
 import { SiteHeader } from "@/components/site-header";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 
-import data from "./data.json";
+import invoiceData from "./invoice-data.json";
 import { ChartBarInteractive } from "@/components/chart-bar-interactive";
 
 export default function Page() {
+  const totalSuccess = invoiceData.filter(
+    (t) => t.run_status === "Completed"
+  ).length;
+  const totalFailed = invoiceData.filter((t) =>
+    t.run_status.includes("Failed")
+  ).length;
+  const partialSuccess = invoiceData.filter(
+    (t) => t.run_status === "Partial Success"
+  ).length;
+  const overallFiles = invoiceData.reduce(
+    (sum, item) => sum + item.total_attachments_in_run,
+    0
+  );
+
+  const chartData = invoiceData
+    .slice()
+    .sort(
+      (a, b) =>
+        new Date(a.run_start_time).getTime() -
+        new Date(b.run_start_time).getTime()
+    )
+    .map((item) => ({
+      date: item.run_start_time,
+      Success: item.files_successfully_processed,
+      Failed: item.files_failed_processing,
+      "Partial Success":
+        item.run_status === "Partial Success"
+          ? item.total_attachments_in_run -
+            (item.files_successfully_processed + item.files_failed_processing)
+          : 0,
+    }));
+
   return (
     <SidebarProvider
       style={
@@ -24,12 +56,17 @@ export default function Page() {
         <div className="flex flex-1 flex-col">
           <div className="@container/main flex flex-1 flex-col gap-2">
             <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-              <SectionCards />
+              <SectionCards
+                totalSuccess={totalSuccess}
+                totalFailed={totalFailed}
+                partialSuccess={partialSuccess}
+                overallFiles={overallFiles}
+              />
               <div className="px-4 lg:px-6">
-                <ChartAreaInteractive />
-                <ChartBarInteractive />
+                <ChartAreaInteractive data={chartData} />
+                <ChartBarInteractive data={chartData} />
               </div>
-              <DataTable data={data} />
+              <DataTable data={invoiceData} />
             </div>
           </div>
         </div>

--- a/src/components/chart-area-interactive.tsx
+++ b/src/components/chart-area-interactive.tsx
@@ -29,34 +29,28 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
 export const description = "An interactive area chart";
 
-const chartData = [
-  { date: "2024-04-01", desktop: 222, mobile: 150 },
-  { date: "2024-04-02", desktop: 97, mobile: 180 },
-  { date: "2024-04-03", desktop: 167, mobile: 120 },
-  { date: "2024-04-04", desktop: 242, mobile: 260 },
-  { date: "2024-04-05", desktop: 373, mobile: 290 },
-  { date: "2024-04-06", desktop: 301, mobile: 340 },
-  { date: "2024-04-07", desktop: 245, mobile: 180 },
-  { date: "2024-04-08", desktop: 409, mobile: 320 },
-  { date: "2024-04-09", desktop: 59, mobile: 110 },
-  { date: "2024-04-10", desktop: 261, mobile: 190 },
-];
-
 const chartConfig = {
-  visitors: {
-    label: "Visitors",
-  },
-  desktop: {
-    label: "Desktop",
-    color: "red",
-  },
-  mobile: {
-    label: "Mobile",
+  Success: {
+    label: "Success",
     color: "green",
   },
+  Failed: {
+    label: "Failed",
+    color: "red",
+  },
+  "Partial Success": {
+    label: "Partial Success",
+    color: "orange",
+  },
 } satisfies ChartConfig;
+export type ChartDatum = {
+  date: string;
+  Success: number;
+  Failed: number;
+  "Partial Success": number;
+};
 
-export function ChartAreaInteractive() {
+export function ChartAreaInteractive({ data }: { data: ChartDatum[] }) {
   const isMobile = useIsMobile();
   const [timeRange, setTimeRange] = React.useState("90d");
 
@@ -66,9 +60,9 @@ export function ChartAreaInteractive() {
     }
   }, [isMobile]);
 
-  const filteredData = chartData.filter((item) => {
+  const filteredData = data.filter((item) => {
     const date = new Date(item.date);
-    const referenceDate = new Date("2024-06-30");
+    const referenceDate = new Date(data[data.length - 1]?.date || 0);
     let daysToSubtract = 90;
     if (timeRange === "30d") {
       daysToSubtract = 30;
@@ -131,13 +125,17 @@ export function ChartAreaInteractive() {
         >
           <AreaChart data={filteredData}>
             <defs>
-              <linearGradient id="fillDesktop" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="red" stopOpacity={1.0} />
-                <stop offset="95%" stopColor="red" stopOpacity={0.1} />
-              </linearGradient>
-              <linearGradient id="fillMobile" x1="0" y1="0" x2="0" y2="1">
+              <linearGradient id="fillSuccess" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="5%" stopColor="green" stopOpacity={0.8} />
                 <stop offset="95%" stopColor="green" stopOpacity={0.1} />
+              </linearGradient>
+              <linearGradient id="fillFailed" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="red" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="red" stopOpacity={0.1} />
+              </linearGradient>
+              <linearGradient id="fillPartial" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="orange" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="orange" stopOpacity={0.1} />
               </linearGradient>
             </defs>
             <CartesianGrid vertical={false} />
@@ -171,17 +169,24 @@ export function ChartAreaInteractive() {
               }
             />
             <Area
-              dataKey="mobile"
+              dataKey="Failed"
               type="natural"
-              fill="url(#fillMobile)"
-              stroke="var(--color-mobile)"
+              fill="url(#fillFailed)"
+              stroke="var(--color-Failed)"
               stackId="a"
             />
             <Area
-              dataKey="desktop"
+              dataKey="Partial Success"
               type="natural"
-              fill="url(#fillDesktop)"
-              stroke="var(--color-desktop)"
+              fill="url(#fillPartial)"
+              stroke="var(--color-Partial Success)"
+              stackId="a"
+            />
+            <Area
+              dataKey="Success"
+              type="natural"
+              fill="url(#fillSuccess)"
+              stroke="var(--color-Success)"
               stackId="a"
             />
           </AreaChart>

--- a/src/components/chart-bar-interactive.tsx
+++ b/src/components/chart-bar-interactive.tsx
@@ -19,124 +19,44 @@ import {
 
 export const description = "An interactive bar chart";
 
-const chartData = [
-  { date: "2024-04-01", desktop: 222, mobile: 150 },
-  { date: "2024-04-02", desktop: 97, mobile: 180 },
-  { date: "2024-04-03", desktop: 167, mobile: 120 },
-  { date: "2024-04-04", desktop: 242, mobile: 260 },
-  { date: "2024-04-05", desktop: 373, mobile: 290 },
-  { date: "2024-04-06", desktop: 301, mobile: 340 },
-  { date: "2024-04-07", desktop: 245, mobile: 180 },
-  { date: "2024-04-08", desktop: 409, mobile: 320 },
-  { date: "2024-04-09", desktop: 59, mobile: 110 },
-  { date: "2024-04-10", desktop: 261, mobile: 190 },
-  { date: "2024-04-11", desktop: 327, mobile: 350 },
-  { date: "2024-04-12", desktop: 292, mobile: 210 },
-  { date: "2024-04-13", desktop: 342, mobile: 380 },
-  { date: "2024-04-14", desktop: 137, mobile: 220 },
-  { date: "2024-04-15", desktop: 120, mobile: 170 },
-  { date: "2024-04-16", desktop: 138, mobile: 190 },
-  { date: "2024-04-17", desktop: 446, mobile: 360 },
-  { date: "2024-04-18", desktop: 364, mobile: 410 },
-  { date: "2024-04-19", desktop: 243, mobile: 180 },
-  { date: "2024-04-20", desktop: 89, mobile: 150 },
-  { date: "2024-04-21", desktop: 137, mobile: 200 },
-  { date: "2024-04-22", desktop: 224, mobile: 170 },
-  { date: "2024-04-23", desktop: 138, mobile: 230 },
-  { date: "2024-04-24", desktop: 387, mobile: 290 },
-  { date: "2024-04-25", desktop: 215, mobile: 250 },
-  { date: "2024-04-26", desktop: 75, mobile: 130 },
-  { date: "2024-04-27", desktop: 383, mobile: 420 },
-  { date: "2024-04-28", desktop: 122, mobile: 180 },
-  { date: "2024-04-29", desktop: 315, mobile: 240 },
-  { date: "2024-04-30", desktop: 454, mobile: 380 },
-  { date: "2024-05-01", desktop: 165, mobile: 220 },
-  { date: "2024-05-02", desktop: 293, mobile: 310 },
-  { date: "2024-05-03", desktop: 247, mobile: 190 },
-  { date: "2024-05-04", desktop: 385, mobile: 420 },
-  { date: "2024-05-05", desktop: 481, mobile: 390 },
-  { date: "2024-05-06", desktop: 498, mobile: 520 },
-  { date: "2024-05-07", desktop: 388, mobile: 300 },
-  { date: "2024-05-08", desktop: 149, mobile: 210 },
-  { date: "2024-05-09", desktop: 227, mobile: 180 },
-  { date: "2024-05-10", desktop: 293, mobile: 330 },
-  { date: "2024-05-11", desktop: 335, mobile: 270 },
-  { date: "2024-05-12", desktop: 197, mobile: 240 },
-  { date: "2024-05-13", desktop: 197, mobile: 160 },
-  { date: "2024-05-14", desktop: 448, mobile: 490 },
-  { date: "2024-05-15", desktop: 473, mobile: 380 },
-  { date: "2024-05-16", desktop: 338, mobile: 400 },
-  { date: "2024-05-17", desktop: 499, mobile: 420 },
-  { date: "2024-05-18", desktop: 315, mobile: 350 },
-  { date: "2024-05-19", desktop: 235, mobile: 180 },
-  { date: "2024-05-20", desktop: 177, mobile: 230 },
-  { date: "2024-05-21", desktop: 82, mobile: 140 },
-  { date: "2024-05-22", desktop: 81, mobile: 120 },
-  { date: "2024-05-23", desktop: 252, mobile: 290 },
-  { date: "2024-05-24", desktop: 294, mobile: 220 },
-  { date: "2024-05-25", desktop: 201, mobile: 250 },
-  { date: "2024-05-26", desktop: 213, mobile: 170 },
-  { date: "2024-05-27", desktop: 420, mobile: 460 },
-  { date: "2024-05-28", desktop: 233, mobile: 190 },
-  { date: "2024-05-29", desktop: 78, mobile: 130 },
-  { date: "2024-05-30", desktop: 340, mobile: 280 },
-  { date: "2024-05-31", desktop: 178, mobile: 230 },
-  { date: "2024-06-01", desktop: 178, mobile: 200 },
-  { date: "2024-06-02", desktop: 470, mobile: 410 },
-  { date: "2024-06-03", desktop: 103, mobile: 160 },
-  { date: "2024-06-04", desktop: 439, mobile: 380 },
-  { date: "2024-06-05", desktop: 88, mobile: 140 },
-  { date: "2024-06-06", desktop: 294, mobile: 250 },
-  { date: "2024-06-07", desktop: 323, mobile: 370 },
-  { date: "2024-06-08", desktop: 385, mobile: 320 },
-  { date: "2024-06-09", desktop: 438, mobile: 480 },
-  { date: "2024-06-10", desktop: 155, mobile: 200 },
-  { date: "2024-06-11", desktop: 92, mobile: 150 },
-  { date: "2024-06-12", desktop: 492, mobile: 420 },
-  { date: "2024-06-13", desktop: 81, mobile: 130 },
-  { date: "2024-06-14", desktop: 426, mobile: 380 },
-  { date: "2024-06-15", desktop: 307, mobile: 350 },
-  { date: "2024-06-16", desktop: 371, mobile: 310 },
-  { date: "2024-06-17", desktop: 475, mobile: 520 },
-  { date: "2024-06-18", desktop: 107, mobile: 170 },
-  { date: "2024-06-19", desktop: 341, mobile: 290 },
-  { date: "2024-06-20", desktop: 408, mobile: 450 },
-  { date: "2024-06-21", desktop: 169, mobile: 210 },
-  { date: "2024-06-22", desktop: 317, mobile: 270 },
-  { date: "2024-06-23", desktop: 480, mobile: 530 },
-  { date: "2024-06-24", desktop: 132, mobile: 180 },
-  { date: "2024-06-25", desktop: 141, mobile: 190 },
-  { date: "2024-06-26", desktop: 434, mobile: 380 },
-  { date: "2024-06-27", desktop: 448, mobile: 490 },
-  { date: "2024-06-28", desktop: 149, mobile: 200 },
-  { date: "2024-06-29", desktop: 103, mobile: 160 },
-  { date: "2024-06-30", desktop: 446, mobile: 400 },
-];
-
 const chartConfig = {
-  views: {
-    label: "Page Views",
+  Success: {
+    label: "Success",
+    color: "var(--chart-1)",
   },
-  desktop: {
-    label: "Email",
+  Failed: {
+    label: "Failed",
     color: "var(--chart-2)",
   },
-  mobile: {
-    label: "Folder",
-    color: "var(--chart-1)",
+  "Partial Success": {
+    label: "Partial Success",
+    color: "var(--chart-3)",
   },
 } satisfies ChartConfig;
 
+export type ChartDatum = {
+  date: string;
+  Success: number;
+  Failed: number;
+  "Partial Success": number;
+};
+
+export function ChartBarInteractive({ data }: { data: ChartDatum[] }) {
+
 export function ChartBarInteractive() {
   const [activeChart, setActiveChart] =
-    React.useState<keyof typeof chartConfig>("desktop");
+    React.useState<keyof typeof chartConfig>("Success");
 
   const total = React.useMemo(
     () => ({
-      desktop: chartData.reduce((acc, curr) => acc + curr.desktop, 0),
-      mobile: chartData.reduce((acc, curr) => acc + curr.mobile, 0),
+      Success: data.reduce((acc, curr) => acc + curr.Success, 0),
+      Failed: data.reduce((acc, curr) => acc + curr.Failed, 0),
+      "Partial Success": data.reduce(
+        (acc, curr) => acc + curr["Partial Success"],
+        0
+      ),
     }),
-    []
+    [data]
   );
 
   return (
@@ -149,7 +69,7 @@ export function ChartBarInteractive() {
           </CardDescription>
         </div>
         <div className="flex">
-          {["desktop", "mobile"].map((key) => {
+          {Object.keys(chartConfig).map((key) => {
             const chart = key as keyof typeof chartConfig;
             return (
               <button
@@ -176,7 +96,7 @@ export function ChartBarInteractive() {
         >
           <BarChart
             accessibilityLayer
-            data={chartData}
+            data={data}
             margin={{
               left: 12,
               right: 12,

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -2,66 +2,25 @@
 
 import * as React from "react";
 import {
-  closestCenter,
-  DndContext,
-  KeyboardSensor,
-  MouseSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-  type UniqueIdentifier,
-} from "@dnd-kit/core";
-import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
-import {
-  arrayMove,
-  SortableContext,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import {
-  IconChevronDown,
-  IconChevronLeft,
-  IconChevronRight,
-  IconChevronsLeft,
-  IconChevronsRight,
-  IconCircleCheckFilled,
-  IconDotsVertical,
-  IconGripVertical,
-  IconLayoutColumns,
-  IconLoader,
-  IconPlus,
-  IconTrendingUp,
-} from "@tabler/icons-react";
-import {
   ColumnDef,
-  ColumnFiltersState,
   flexRender,
   getCoreRowModel,
-  getFacetedRowModel,
-  getFacetedUniqueValues,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
-  Row,
-  SortingState,
   useReactTable,
-  VisibilityState,
+  getSortedRowModel,
+  SortingState,
 } from "@tanstack/react-table";
-import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
-import { toast } from "sonner";
 import { z } from "zod";
+import {
+  IconCheck,
+  IconX,
+  IconAlertTriangle,
+  IconMinus,
+  IconDotsVertical,
+} from "@tabler/icons-react";
 
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   Drawer,
@@ -73,23 +32,6 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer";
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import {
   Table,
@@ -99,836 +41,351 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-export const schema = z.object({
-  id: z.number(),
-  header: z.string(),
-  type: z.string(),
-  status: z.string(),
-  target: z.string(),
-  limit: z.string(),
-  reviewer: z.string(),
+export const fileProcessedSchema = z.object({
+  id: z.string(),
+  file_name: z.string(),
+  bod_id: z.string().nullable(),
+  bod_status: z.string().nullable(),
+  doc_added_to_idm: z.boolean(),
+  notification_sent: z.boolean(),
+  idp_status: z.string().nullable(),
+  idp_response_code: z.union([z.string(), z.number()]).nullable(),
+  fields: z.record(z.string(), z.any()).nullable(),
+  items: z.array(z.record(z.string(), z.any())),
+  file_status: z.string(),
+  raw_content_snippet: z.string().optional(),
+  errors: z.array(z.string()),
 });
 
-// Create a separate component for the drag handle
-function DragHandle({ id }: { id: number }) {
-  const { attributes, listeners } = useSortable({
-    id,
-  });
+export const invoiceDataSchema = z.object({
+  transaction_id: z.string(),
+  source_log_file: z.string(),
+  run_start_time: z.string(),
+  run_end_time: z.string().nullable(),
+  email_response_status_code: z.string().nullable(),
+  total_email_count: z.string().nullable(),
+  subject: z.string(),
+  files_processed: z.array(fileProcessedSchema),
+  total_attachments_in_run: z.number(),
+  files_successfully_processed: z.number(),
+  files_failed_processing: z.number(),
+  run_status: z.string(),
+  applied_rules: z
+    .array(
+      z.object({
+        rule_id: z.string().optional(),
+        rule_name: z.string().optional(),
+        action: z.string().optional(),
+        matched_field: z.string().optional(),
+        matched_value: z.string().optional(),
+        context: z.string().optional(),
+      })
+    )
+    .optional(),
+});
 
-  return (
-    <Button
-      {...attributes}
-      {...listeners}
-      variant="ghost"
-      size="icon"
-      className="text-muted-foreground size-7 hover:bg-transparent"
-    >
-      <IconGripVertical className="text-muted-foreground size-3" />
-      <span className="sr-only">Drag to reorder</span>
-    </Button>
-  );
-}
+export type InvoiceData = z.infer<typeof invoiceDataSchema>;
 
-const columns: ColumnDef<z.infer<typeof schema>>[] = [
-  {
-    id: "drag",
-    header: () => null,
-    cell: ({ row }) => <DragHandle id={row.original.id} />,
-  },
-  {
-    id: "select",
-    header: ({ table }) => (
-      <div className="flex items-center justify-center">
-        <Checkbox
-          checked={
-            table.getIsAllPageRowsSelected() ||
-            (table.getIsSomePageRowsSelected() && "indeterminate")
-          }
-          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-          aria-label="Select all"
-        />
-      </div>
-    ),
-    cell: ({ row }) => (
-      <div className="flex items-center justify-center">
-        <Checkbox
-          checked={row.getIsSelected()}
-          onCheckedChange={(value) => row.toggleSelected(!!value)}
-          aria-label="Select row"
-        />
-      </div>
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  },
-  {
-    accessorKey: "header",
-    header: "Header",
-    cell: ({ row }) => {
-      return <TableCellViewer item={row.original} />;
-    },
-    enableHiding: false,
-  },
-  {
-    accessorKey: "type",
-    header: "Section Type",
-    cell: ({ row }) => (
-      <div className="w-32">
-        <Badge variant="outline" className="text-muted-foreground px-1.5">
-          {row.original.type}
-        </Badge>
-      </div>
-    ),
-  },
-  {
-    accessorKey: "status",
-    header: "Status",
-    cell: ({ row }) => (
-      <Badge variant="outline" className="text-muted-foreground px-1.5">
-        {row.original.status === "Done" ? (
-          <IconCircleCheckFilled className="fill-green-500 dark:fill-green-400" />
-        ) : (
-          <IconLoader />
-        )}
-        {row.original.status}
-      </Badge>
-    ),
-  },
-  {
-    accessorKey: "target",
-    header: () => <div className="w-full text-right">Target</div>,
-    cell: ({ row }) => (
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          toast.promise(new Promise((resolve) => setTimeout(resolve, 1000)), {
-            loading: `Saving ${row.original.header}`,
-            success: "Done",
-            error: "Error",
-          });
-        }}
-      >
-        <Label htmlFor={`${row.original.id}-target`} className="sr-only">
-          Target
-        </Label>
-        <Input
-          className="hover:bg-input/30 focus-visible:bg-background dark:hover:bg-input/30 dark:focus-visible:bg-input/30 h-8 w-16 border-transparent bg-transparent text-right shadow-none focus-visible:border dark:bg-transparent"
-          defaultValue={row.original.target}
-          id={`${row.original.id}-target`}
-        />
-      </form>
-    ),
-  },
-  {
-    accessorKey: "limit",
-    header: () => <div className="w-full text-right">Limit</div>,
-    cell: ({ row }) => (
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          toast.promise(new Promise((resolve) => setTimeout(resolve, 1000)), {
-            loading: `Saving ${row.original.header}`,
-            success: "Done",
-            error: "Error",
-          });
-        }}
-      >
-        <Label htmlFor={`${row.original.id}-limit`} className="sr-only">
-          Limit
-        </Label>
-        <Input
-          className="hover:bg-input/30 focus-visible:bg-background dark:hover:bg-input/30 dark:focus-visible:bg-input/30 h-8 w-16 border-transparent bg-transparent text-right shadow-none focus-visible:border dark:bg-transparent"
-          defaultValue={row.original.limit}
-          id={`${row.original.id}-limit`}
-        />
-      </form>
-    ),
-  },
-  {
-    accessorKey: "reviewer",
-    header: "Reviewer",
-    cell: ({ row }) => {
-      const isAssigned = row.original.reviewer !== "Assign reviewer";
-
-      if (isAssigned) {
-        return row.original.reviewer;
-      }
-
-      return (
-        <>
-          <Label htmlFor={`${row.original.id}-reviewer`} className="sr-only">
-            Reviewer
-          </Label>
-          <Select>
-            <SelectTrigger
-              className="w-38 **:data-[slot=select-value]:block **:data-[slot=select-value]:truncate"
-              size="sm"
-              id={`${row.original.id}-reviewer`}
-            >
-              <SelectValue placeholder="Assign reviewer" />
-            </SelectTrigger>
-            <SelectContent align="end">
-              <SelectItem value="Eddie Lake">Eddie Lake</SelectItem>
-              <SelectItem value="Jamik Tashpulatov">
-                Jamik Tashpulatov
-              </SelectItem>
-            </SelectContent>
-          </Select>
-        </>
-      );
-    },
-  },
-  {
-    id: "actions",
-    cell: () => (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            className="data-[state=open]:bg-muted text-muted-foreground flex size-8"
-            size="icon"
-          >
-            <IconDotsVertical />
-            <span className="sr-only">Open menu</span>
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-32">
-          <DropdownMenuItem>Edit</DropdownMenuItem>
-          <DropdownMenuItem>Make a copy</DropdownMenuItem>
-          <DropdownMenuItem>Favorite</DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    ),
-  },
-];
-
-function DraggableRow({ row }: { row: Row<z.infer<typeof schema>> }) {
-  const { transform, transition, setNodeRef, isDragging } = useSortable({
-    id: row.original.id,
-  });
-
-  return (
-    <TableRow
-      data-state={row.getIsSelected() && "selected"}
-      data-dragging={isDragging}
-      ref={setNodeRef}
-      className="relative z-0 data-[dragging=true]:z-10 data-[dragging=true]:opacity-80"
-      style={{
-        transform: CSS.Transform.toString(transform),
-        transition: transition,
-      }}
-    >
-      {row.getVisibleCells().map((cell) => (
-        <TableCell key={cell.id}>
-          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-        </TableCell>
-      ))}
-    </TableRow>
-  );
-}
-
-export function DataTable({
-  data: initialData,
-}: {
-  data: z.infer<typeof schema>[];
-}) {
-  const [data, setData] = React.useState(() => initialData);
-  const [rowSelection, setRowSelection] = React.useState({});
-  const [columnVisibility, setColumnVisibility] =
-    React.useState<VisibilityState>({});
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    []
-  );
-  const [sorting, setSorting] = React.useState<SortingState>([]);
-  const [pagination, setPagination] = React.useState({
-    pageIndex: 0,
-    pageSize: 10,
-  });
-  const sortableId = React.useId();
-  const sensors = useSensors(
-    useSensor(MouseSensor, {}),
-    useSensor(TouchSensor, {}),
-    useSensor(KeyboardSensor, {})
-  );
-
-  const dataIds = React.useMemo<UniqueIdentifier[]>(
-    () => data?.map(({ id }) => id) || [],
-    [data]
-  );
-
-  const table = useReactTable({
-    data,
-    columns,
-    state: {
-      sorting,
-      columnVisibility,
-      rowSelection,
-      columnFilters,
-      pagination,
-    },
-    getRowId: (row) => row.id.toString(),
-    enableRowSelection: true,
-    onRowSelectionChange: setRowSelection,
-    onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
-    onColumnVisibilityChange: setColumnVisibility,
-    onPaginationChange: setPagination,
-    getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFacetedRowModel: getFacetedRowModel(),
-    getFacetedUniqueValues: getFacetedUniqueValues(),
-  });
-
-  function handleDragEnd(event: DragEndEvent) {
-    const { active, over } = event;
-    if (active && over && active.id !== over.id) {
-      setData((data) => {
-        const oldIndex = dataIds.indexOf(active.id);
-        const newIndex = dataIds.indexOf(over.id);
-        return arrayMove(data, oldIndex, newIndex);
-      });
-    }
+function StatusBadge({ status }: { status: string }) {
+  let color = "bg-gray-300 text-black";
+  let Icon = IconMinus;
+  if (status === "Completed") {
+    color = "bg-green-500 text-white";
+    Icon = IconCheck;
+  } else if (status.includes("Failed")) {
+    color = "bg-red-500 text-white";
+    Icon = IconX;
+  } else if (status === "Partial Success") {
+    color = "bg-amber-500 text-white";
+    Icon = IconAlertTriangle;
   }
-
   return (
-    <Tabs
-      defaultValue="outline"
-      className="w-full flex-col justify-start gap-6"
-    >
-      <div className="flex items-center justify-between px-4 lg:px-6">
-        <Label htmlFor="view-selector" className="sr-only">
-          View
-        </Label>
-        <Select defaultValue="outline">
-          <SelectTrigger
-            className="flex w-fit @4xl/main:hidden"
-            size="sm"
-            id="view-selector"
-          >
-            <SelectValue placeholder="Select a view" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="outline">Outline</SelectItem>
-            <SelectItem value="past-performance">Past Performance</SelectItem>
-            <SelectItem value="key-personnel">Key Personnel</SelectItem>
-            <SelectItem value="focus-documents">Focus Documents</SelectItem>
-          </SelectContent>
-        </Select>
-        <TabsList className="**:data-[slot=badge]:bg-muted-foreground/30 hidden **:data-[slot=badge]:size-5 **:data-[slot=badge]:rounded-full **:data-[slot=badge]:px-1 @4xl/main:flex">
-          <TabsTrigger value="outline">Outline</TabsTrigger>
-          <TabsTrigger value="past-performance">
-            Past Performance <Badge variant="secondary">3</Badge>
-          </TabsTrigger>
-          <TabsTrigger value="key-personnel">
-            Key Personnel <Badge variant="secondary">2</Badge>
-          </TabsTrigger>
-          <TabsTrigger value="focus-documents">Focus Documents</TabsTrigger>
-        </TabsList>
-        <div className="flex items-center gap-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm">
-                <IconLayoutColumns />
-                <span className="hidden lg:inline">Customize Columns</span>
-                <span className="lg:hidden">Columns</span>
-                <IconChevronDown />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
-              {table
-                .getAllColumns()
-                .filter(
-                  (column) =>
-                    typeof column.accessorFn !== "undefined" &&
-                    column.getCanHide()
-                )
-                .map((column) => {
-                  return (
-                    <DropdownMenuCheckboxItem
-                      key={column.id}
-                      className="capitalize"
-                      checked={column.getIsVisible()}
-                      onCheckedChange={(value) =>
-                        column.toggleVisibility(!!value)
-                      }
-                    >
-                      {column.id}
-                    </DropdownMenuCheckboxItem>
-                  );
-                })}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <Button variant="outline" size="sm">
-            <IconPlus />
-            <span className="hidden lg:inline">Add Section</span>
-          </Button>
-        </div>
-      </div>
-      <TabsContent
-        value="outline"
-        className="relative flex flex-col gap-4 overflow-auto px-4 lg:px-6"
-      >
-        <div className="overflow-hidden rounded-lg border">
-          <DndContext
-            collisionDetection={closestCenter}
-            modifiers={[restrictToVerticalAxis]}
-            onDragEnd={handleDragEnd}
-            sensors={sensors}
-            id={sortableId}
-          >
-            <Table>
-              <TableHeader className="bg-muted sticky top-0 z-10">
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <TableRow key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => {
-                      return (
-                        <TableHead key={header.id} colSpan={header.colSpan}>
-                          {header.isPlaceholder
-                            ? null
-                            : flexRender(
-                                header.column.columnDef.header,
-                                header.getContext()
-                              )}
-                        </TableHead>
-                      );
-                    })}
-                  </TableRow>
-                ))}
-              </TableHeader>
-              <TableBody className="**:data-[slot=table-cell]:first:w-8">
-                {table.getRowModel().rows?.length ? (
-                  <SortableContext
-                    items={dataIds}
-                    strategy={verticalListSortingStrategy}
-                  >
-                    {table.getRowModel().rows.map((row) => (
-                      <DraggableRow key={row.id} row={row} />
-                    ))}
-                  </SortableContext>
-                ) : (
-                  <TableRow>
-                    <TableCell
-                      colSpan={columns.length}
-                      className="h-24 text-center"
-                    >
-                      No results.
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </DndContext>
-        </div>
-        <div className="flex items-center justify-between px-4">
-          <div className="text-muted-foreground hidden flex-1 text-sm lg:flex">
-            {table.getFilteredSelectedRowModel().rows.length} of{" "}
-            {table.getFilteredRowModel().rows.length} row(s) selected.
-          </div>
-          <div className="flex w-full items-center gap-8 lg:w-fit">
-            <div className="hidden items-center gap-2 lg:flex">
-              <Label htmlFor="rows-per-page" className="text-sm font-medium">
-                Rows per page
-              </Label>
-              <Select
-                value={`${table.getState().pagination.pageSize}`}
-                onValueChange={(value) => {
-                  table.setPageSize(Number(value));
-                }}
-              >
-                <SelectTrigger size="sm" className="w-20" id="rows-per-page">
-                  <SelectValue
-                    placeholder={table.getState().pagination.pageSize}
-                  />
-                </SelectTrigger>
-                <SelectContent side="top">
-                  {[10, 20, 30, 40, 50].map((pageSize) => (
-                    <SelectItem key={pageSize} value={`${pageSize}`}>
-                      {pageSize}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex w-fit items-center justify-center text-sm font-medium">
-              Page {table.getState().pagination.pageIndex + 1} of{" "}
-              {table.getPageCount()}
-            </div>
-            <div className="ml-auto flex items-center gap-2 lg:ml-0">
-              <Button
-                variant="outline"
-                className="hidden h-8 w-8 p-0 lg:flex"
-                onClick={() => table.setPageIndex(0)}
-                disabled={!table.getCanPreviousPage()}
-              >
-                <span className="sr-only">Go to first page</span>
-                <IconChevronsLeft />
-              </Button>
-              <Button
-                variant="outline"
-                className="size-8"
-                size="icon"
-                onClick={() => table.previousPage()}
-                disabled={!table.getCanPreviousPage()}
-              >
-                <span className="sr-only">Go to previous page</span>
-                <IconChevronLeft />
-              </Button>
-              <Button
-                variant="outline"
-                className="size-8"
-                size="icon"
-                onClick={() => table.nextPage()}
-                disabled={!table.getCanNextPage()}
-              >
-                <span className="sr-only">Go to next page</span>
-                <IconChevronRight />
-              </Button>
-              <Button
-                variant="outline"
-                className="hidden size-8 lg:flex"
-                size="icon"
-                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-                disabled={!table.getCanNextPage()}
-              >
-                <span className="sr-only">Go to last page</span>
-                <IconChevronsRight />
-              </Button>
-            </div>
-          </div>
-        </div>
-      </TabsContent>
-      <TabsContent
-        value="past-performance"
-        className="flex flex-col px-4 lg:px-6"
-      >
-        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed">
-          <div className="overflow-hidden rounded-lg border">
-            <DndContext
-              collisionDetection={closestCenter}
-              modifiers={[restrictToVerticalAxis]}
-              onDragEnd={handleDragEnd}
-              sensors={sensors}
-              id={sortableId}
-            >
-              <Table>
-                <TableHeader className="bg-muted sticky top-0 z-10">
-                  {table.getHeaderGroups().map((headerGroup) => (
-                    <TableRow key={headerGroup.id}>
-                      {headerGroup.headers.map((header) => {
-                        return (
-                          <TableHead key={header.id} colSpan={header.colSpan}>
-                            {header.isPlaceholder
-                              ? null
-                              : flexRender(
-                                  header.column.columnDef.header,
-                                  header.getContext()
-                                )}
-                          </TableHead>
-                        );
-                      })}
-                    </TableRow>
-                  ))}
-                </TableHeader>
-                <TableBody className="**:data-[slot=table-cell]:first:w-8">
-                  {table.getRowModel().rows?.length ? (
-                    <SortableContext
-                      items={dataIds}
-                      strategy={verticalListSortingStrategy}
-                    >
-                      {table.getRowModel().rows.map((row) => (
-                        <DraggableRow key={row.id} row={row} />
-                      ))}
-                    </SortableContext>
-                  ) : (
-                    <TableRow>
-                      <TableCell
-                        colSpan={columns.length}
-                        className="h-24 text-center"
-                      >
-                        No results.
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-            </DndContext>
-          </div>
-          <div className="flex items-center justify-between px-4">
-            <div className="text-muted-foreground hidden flex-1 text-sm lg:flex">
-              {table.getFilteredSelectedRowModel().rows.length} of{" "}
-              {table.getFilteredRowModel().rows.length} row(s) selected.
-            </div>
-            <div className="flex w-full items-center gap-8 lg:w-fit">
-              <div className="hidden items-center gap-2 lg:flex">
-                <Label htmlFor="rows-per-page" className="text-sm font-medium">
-                  Rows per page
-                </Label>
-                <Select
-                  value={`${table.getState().pagination.pageSize}`}
-                  onValueChange={(value) => {
-                    table.setPageSize(Number(value));
-                  }}
-                >
-                  <SelectTrigger size="sm" className="w-20" id="rows-per-page">
-                    <SelectValue
-                      placeholder={table.getState().pagination.pageSize}
-                    />
-                  </SelectTrigger>
-                  <SelectContent side="top">
-                    {[10, 20, 30, 40, 50].map((pageSize) => (
-                      <SelectItem key={pageSize} value={`${pageSize}`}>
-                        {pageSize}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="flex w-fit items-center justify-center text-sm font-medium">
-                Page {table.getState().pagination.pageIndex + 1} of{" "}
-                {table.getPageCount()}
-              </div>
-              <div className="ml-auto flex items-center gap-2 lg:ml-0">
-                <Button
-                  variant="outline"
-                  className="hidden h-8 w-8 p-0 lg:flex"
-                  onClick={() => table.setPageIndex(0)}
-                  disabled={!table.getCanPreviousPage()}
-                >
-                  <span className="sr-only">Go to first page</span>
-                  <IconChevronsLeft />
-                </Button>
-                <Button
-                  variant="outline"
-                  className="size-8"
-                  size="icon"
-                  onClick={() => table.previousPage()}
-                  disabled={!table.getCanPreviousPage()}
-                >
-                  <span className="sr-only">Go to previous page</span>
-                  <IconChevronLeft />
-                </Button>
-                <Button
-                  variant="outline"
-                  className="size-8"
-                  size="icon"
-                  onClick={() => table.nextPage()}
-                  disabled={!table.getCanNextPage()}
-                >
-                  <span className="sr-only">Go to next page</span>
-                  <IconChevronRight />
-                </Button>
-                <Button
-                  variant="outline"
-                  className="hidden size-8 lg:flex"
-                  size="icon"
-                  onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-                  disabled={!table.getCanNextPage()}
-                >
-                  <span className="sr-only">Go to last page</span>
-                  <IconChevronsRight />
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </TabsContent>
-      <TabsContent value="key-personnel" className="flex flex-col px-4 lg:px-6">
-        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
-      </TabsContent>
-      <TabsContent
-        value="focus-documents"
-        className="flex flex-col px-4 lg:px-6"
-      >
-        <div className="aspect-video w-full flex-1 rounded-lg border border-dashed"></div>
-      </TabsContent>
-    </Tabs>
+    <Badge className={color} variant="default">
+      <Icon className="mr-1 size-4" /> {status}
+    </Badge>
   );
 }
 
-const chartData = [
-  { month: "January", desktop: 186, mobile: 80 },
-  { month: "February", desktop: 305, mobile: 200 },
-  { month: "March", desktop: 237, mobile: 120 },
-  { month: "April", desktop: 73, mobile: 190 },
-  { month: "May", desktop: 209, mobile: 130 },
-  { month: "June", desktop: 214, mobile: 140 },
-];
-
-const chartConfig = {
-  desktop: {
-    label: "Desktop",
-    color: "var(--primary)",
-  },
-  mobile: {
-    label: "Mobile",
-    color: "var(--primary)",
-  },
-} satisfies ChartConfig;
-
-function TableCellViewer({ item }: { item: z.infer<typeof schema> }) {
+function TransactionDrawer({ item }: { item: InvoiceData }) {
   const isMobile = useIsMobile();
-
   return (
     <Drawer direction={isMobile ? "bottom" : "right"}>
       <DrawerTrigger asChild>
-        <Button variant="link" className="text-foreground w-fit px-0 text-left">
-          {item.header}
+        <Button variant="link" className="px-0 text-left">
+          {item.transaction_id}
         </Button>
       </DrawerTrigger>
       <DrawerContent>
         <DrawerHeader className="gap-1">
-          <DrawerTitle>{item.header}</DrawerTitle>
-          <DrawerDescription>
-            Showing total visitors for the last 6 months
-          </DrawerDescription>
+          <DrawerTitle>
+            Transaction Details - ID: {item.transaction_id}
+          </DrawerTitle>
         </DrawerHeader>
         <div className="flex flex-col gap-4 overflow-y-auto px-4 text-sm">
-          {!isMobile && (
-            <>
-              <ChartContainer config={chartConfig}>
-                <AreaChart
-                  accessibilityLayer
-                  data={chartData}
-                  margin={{
-                    left: 0,
-                    right: 10,
-                  }}
-                >
-                  <CartesianGrid vertical={false} />
-                  <XAxis
-                    dataKey="month"
-                    tickLine={false}
-                    axisLine={false}
-                    tickMargin={8}
-                    tickFormatter={(value) => value.slice(0, 3)}
-                    hide
-                  />
-                  <ChartTooltip
-                    cursor={false}
-                    content={<ChartTooltipContent indicator="dot" />}
-                  />
-                  <Area
-                    dataKey="mobile"
-                    type="natural"
-                    fill="var(--color-mobile)"
-                    fillOpacity={0.6}
-                    stroke="var(--color-mobile)"
-                    stackId="a"
-                  />
-                  <Area
-                    dataKey="desktop"
-                    type="natural"
-                    fill="var(--color-desktop)"
-                    fillOpacity={0.4}
-                    stroke="var(--color-desktop)"
-                    stackId="a"
-                  />
-                </AreaChart>
-              </ChartContainer>
+          <div>
+            <span className="font-medium">Subject:</span> {item.subject}
+          </div>
+          <div>
+            <span className="font-medium">Run Status:</span> {item.run_status}
+          </div>
+          <div>
+            <span className="font-medium">Run Start Time:</span>{" "}
+            {new Date(item.run_start_time).toLocaleString()}
+          </div>
+          <div>
+            <span className="font-medium">Run End Time:</span>{" "}
+            {item.run_end_time
+              ? new Date(item.run_end_time).toLocaleString()
+              : "N/A"}
+          </div>
+          <div>
+            <span className="font-medium">Email Response Status Code:</span>{" "}
+            {item.email_response_status_code || "N/A"}
+          </div>
+          <div>
+            <span className="font-medium">Total Email Count:</span>{" "}
+            {item.total_email_count || "N/A"}
+          </div>
+          <div>
+            <span className="font-medium">Source Log File:</span>{" "}
+            {item.source_log_file}
+          </div>
+          <div>
+            <span className="font-medium">Total Attachments in Run:</span>{" "}
+            {item.total_attachments_in_run}
+          </div>
+          <div>
+            <span className="font-medium">Files Successfully Processed:</span>{" "}
+            {item.files_successfully_processed}
+          </div>
+          <div>
+            <span className="font-medium">Files Failed Processing:</span>{" "}
+            {item.files_failed_processing}
+          </div>
+          {item.applied_rules && item.applied_rules.length > 0 && (
+            <div className="space-y-2">
               <Separator />
-              <div className="grid gap-2">
-                <div className="flex gap-2 leading-none font-medium">
-                  Trending up by 5.2% this month{" "}
-                  <IconTrendingUp className="size-4" />
+              <div className="font-medium">Applied Rules</div>
+              {item.applied_rules.map((rule, idx) => (
+                <div key={idx} className="pl-2">
+                  <div>
+                    <span className="font-medium">Rule:</span> {rule.rule_name}
+                  </div>
+                  {rule.action && (
+                    <div>
+                      <span className="font-medium">Action:</span> {rule.action}
+                    </div>
+                  )}
+                  {rule.context && (
+                    <div>
+                      <span className="font-medium">Context:</span> {rule.context}
+                    </div>
+                  )}
                 </div>
-                <div className="text-muted-foreground">
-                  Showing total visitors for the last 6 months. This is just
-                  some random text to test the layout. It spans multiple lines
-                  and should wrap around.
-                </div>
-              </div>
-              <Separator />
-            </>
+              ))}
+            </div>
           )}
-          <form className="flex flex-col gap-4">
-            <div className="flex flex-col gap-3">
-              <Label htmlFor="header">Header</Label>
-              <Input id="header" defaultValue={item.header} />
+          {item.files_processed.length > 0 && (
+            <div className="space-y-2">
+              <Separator />
+              <div className="font-medium">Files Processed</div>
+              {item.files_processed.map((file) => (
+                <div key={file.id} className="border p-2 rounded-md space-y-1">
+                  <div className="font-medium">{file.file_name}</div>
+                  <div>
+                    <span className="font-medium">File Status:</span> {file.file_status}
+                  </div>
+                  <div>
+                    <span className="font-medium">BOD ID:</span>{" "}
+                    {file.bod_id || "N/A"}
+                  </div>
+                  <div>
+                    <span className="font-medium">BOD Status:</span>{" "}
+                    {file.bod_status || "N/A"}
+                  </div>
+                  <div>
+                    <span className="font-medium">IDP Status:</span> {file.idp_status || "N/A"}
+                  </div>
+                  <div>
+                    <span className="font-medium">Doc Added to IDM:</span>{" "}
+                    {file.doc_added_to_idm ? "Yes" : "No"}
+                  </div>
+                  <div>
+                    <span className="font-medium">Notification Sent:</span>{" "}
+                    {file.notification_sent ? "Yes" : "No"}
+                  </div>
+                  {file.fields && (
+                    <div>
+                      <span className="font-medium">Fields:</span>
+                      <pre className="whitespace-pre-wrap text-xs">
+{JSON.stringify(file.fields, null, 2)}
+</pre>
+                    </div>
+                  )}
+                  {file.items.length > 0 && (
+                    <div>
+                      <span className="font-medium">Items:</span>
+                      <pre className="whitespace-pre-wrap text-xs">
+{JSON.stringify(file.items, null, 2)}
+</pre>
+                    </div>
+                  )}
+                  {file.errors.length > 0 && (
+                    <div>
+                      <span className="font-medium">Errors:</span>
+                      <ul className="list-disc pl-4">
+                        {file.errors.map((err, i) => (
+                          <li key={i}>{err}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              ))}
             </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-3">
-                <Label htmlFor="type">Type</Label>
-                <Select defaultValue={item.type}>
-                  <SelectTrigger id="type" className="w-full">
-                    <SelectValue placeholder="Select a type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="Table of Contents">
-                      Table of Contents
-                    </SelectItem>
-                    <SelectItem value="Executive Summary">
-                      Executive Summary
-                    </SelectItem>
-                    <SelectItem value="Technical Approach">
-                      Technical Approach
-                    </SelectItem>
-                    <SelectItem value="Design">Design</SelectItem>
-                    <SelectItem value="Capabilities">Capabilities</SelectItem>
-                    <SelectItem value="Focus Documents">
-                      Focus Documents
-                    </SelectItem>
-                    <SelectItem value="Narrative">Narrative</SelectItem>
-                    <SelectItem value="Cover Page">Cover Page</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="flex flex-col gap-3">
-                <Label htmlFor="status">Status</Label>
-                <Select defaultValue={item.status}>
-                  <SelectTrigger id="status" className="w-full">
-                    <SelectValue placeholder="Select a status" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="Done">Done</SelectItem>
-                    <SelectItem value="In Progress">In Progress</SelectItem>
-                    <SelectItem value="Not Started">Not Started</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="flex flex-col gap-3">
-                <Label htmlFor="target">Target</Label>
-                <Input id="target" defaultValue={item.target} />
-              </div>
-              <div className="flex flex-col gap-3">
-                <Label htmlFor="limit">Limit</Label>
-                <Input id="limit" defaultValue={item.limit} />
-              </div>
-            </div>
-            <div className="flex flex-col gap-3">
-              <Label htmlFor="reviewer">Reviewer</Label>
-              <Select defaultValue={item.reviewer}>
-                <SelectTrigger id="reviewer" className="w-full">
-                  <SelectValue placeholder="Select a reviewer" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="Eddie Lake">Eddie Lake</SelectItem>
-                  <SelectItem value="Jamik Tashpulatov">
-                    Jamik Tashpulatov
-                  </SelectItem>
-                  <SelectItem value="Emily Whalen">Emily Whalen</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </form>
+          )}
         </div>
         <DrawerFooter>
-          <Button>Submit</Button>
+          <Button onClick={() => console.log("view", item.transaction_id)}>
+            View Details
+          </Button>
           <DrawerClose asChild>
-            <Button variant="outline">Done</Button>
+            <Button variant="outline">Close</Button>
           </DrawerClose>
         </DrawerFooter>
       </DrawerContent>
     </Drawer>
   );
 }
+
+const columns: ColumnDef<InvoiceData>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "transaction_id",
+    header: "Transaction ID",
+    cell: ({ row }) => <TransactionDrawer item={row.original} />,
+  },
+  {
+    accessorKey: "subject",
+    header: "Subject",
+  },
+  {
+    accessorKey: "run_status",
+    header: "Run Status",
+    cell: ({ row }) => <StatusBadge status={row.original.run_status} />,
+  },
+  {
+    accessorKey: "total_attachments_in_run",
+    header: () => <div className="text-center">Total Attachments</div>,
+    cell: ({ row }) => (
+      <div className="text-center">
+        {row.original.total_attachments_in_run}
+      </div>
+    ),
+  },
+  {
+    accessorKey: "files_successfully_processed",
+    header: () => <div className="text-center">Success</div>,
+    cell: ({ row }) => (
+      <div className="text-green-600 text-center">
+        {row.original.files_successfully_processed}
+      </div>
+    ),
+  },
+  {
+    accessorKey: "files_failed_processing",
+    header: () => <div className="text-center">Failed</div>,
+    cell: ({ row }) => (
+      <div className="text-red-600 text-center">
+        {row.original.files_failed_processing}
+      </div>
+    ),
+  },
+  {
+    id: "actions",
+    cell: () => (
+      <Button variant="ghost" size="icon">
+        <IconDotsVertical />
+      </Button>
+    ),
+  },
+];
+
+export function DataTable({ data }: { data: InvoiceData[] }) {
+  const [rowSelection, setRowSelection] = React.useState({});
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { rowSelection, sorting },
+    enableRowSelection: true,
+    onRowSelectionChange: setRowSelection,
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader className="bg-muted sticky top-0 z-10">
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id} colSpan={header.colSpan}>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.map((row) => (
+            <TableRow
+              key={row.id}
+              data-state={row.getIsSelected() && "selected"}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
 export function DataTableSkeleton() {
   return (
     <div className="flex flex-col gap-4 px-4 lg:px-6">

--- a/src/components/section-cards.tsx
+++ b/src/components/section-cards.tsx
@@ -1,4 +1,9 @@
-import { IconTrendingDown, IconTrendingUp } from "@tabler/icons-react";
+import {
+  IconCheck,
+  IconX,
+  IconAlertTriangle,
+  IconFile,
+} from "@tabler/icons-react";
 
 import { Badge } from "@/components/ui/badge";
 import {
@@ -10,91 +15,81 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-export function SectionCards() {
+export function SectionCards({
+  totalSuccess,
+  totalFailed,
+  partialSuccess,
+  overallFiles,
+}: {
+  totalSuccess: number;
+  totalFailed: number;
+  partialSuccess: number;
+  overallFiles: number;
+}) {
   return (
     <div className="*:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card grid grid-cols-1 gap-4 px-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:shadow-xs lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
       <Card className="@container/card">
         <CardHeader>
           <CardDescription>Total Success</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            $1,250.00
+            {totalSuccess.toLocaleString()}
           </CardTitle>
           <CardAction>
             <Badge className="bg-green-500 text-white" variant="default">
-              <IconTrendingUp />
-              +12.5%
+              <IconCheck />
             </Badge>
           </CardAction>
         </CardHeader>
         <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Trending up this month <IconTrendingUp className="size-4" />
-          </div>
-          <div className="text-muted-foreground">
-            Visitors for the last 6 months
-          </div>
+          <div className="text-muted-foreground">Completed runs</div>
         </CardFooter>
       </Card>
       <Card className="@container/card">
         <CardHeader>
           <CardDescription>Total Failures</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            1,234
+            {totalFailed.toLocaleString()}
           </CardTitle>
           <CardAction>
             <Badge className="bg-red-500 text-white" variant="default">
-              <IconTrendingDown />
-              -20%
+              <IconX />
             </Badge>
           </CardAction>
         </CardHeader>
         <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Down 20% this period <IconTrendingDown className="size-4" />
-          </div>
-          <div className="text-muted-foreground">
-            Acquisition needs attention
-          </div>
+          <div className="text-muted-foreground">Runs with failures</div>
         </CardFooter>
       </Card>
       <Card className="@container/card">
         <CardHeader>
           <CardDescription>Partial Success</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            45,678
+            {partialSuccess.toLocaleString()}
           </CardTitle>
           <CardAction>
             <Badge className="bg-amber-500 text-white" variant="default">
-              <IconTrendingUp />
-              +12.5%
+              <IconAlertTriangle />
             </Badge>
           </CardAction>
         </CardHeader>
         <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Strong user retention <IconTrendingUp className="size-4" />
-          </div>
-          <div className="text-muted-foreground">Engagement exceed targets</div>
+          <div className="text-muted-foreground">Runs partially successful</div>
         </CardFooter>
       </Card>
       <Card className="@container/card">
         <CardHeader>
           <CardDescription>Overall Files</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            4.5%
+            {overallFiles.toLocaleString()}
           </CardTitle>
           <CardAction>
             <Badge className="bg-gray-200 text-black" variant="default">
-              <IconTrendingUp />
-              +4.5%
+              <IconFile />
             </Badge>
           </CardAction>
         </CardHeader>
         <CardFooter className="flex-col items-start gap-1.5 text-sm">
-          <div className="line-clamp-1 flex gap-2 font-medium">
-            Steady performance increase <IconTrendingUp className="size-4" />
-          </div>
-          <div className="text-muted-foreground">Meets growth projections</div>
+          <div className="text-muted-foreground">Files processed overall</div>
         </CardFooter>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- swap to `invoice-data.json` for dashboard
- compute aggregate totals in the main page
- make `SectionCards` display the calculated totals
- create new invoice-focused `DataTable` with drawer details
- update charts to show invoice success metrics

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6841ed96ca4c83319c43eef77a644579